### PR TITLE
remove use of deprecated endpoint

### DIFF
--- a/lib/TetrisApp.js
+++ b/lib/TetrisApp.js
@@ -22,7 +22,7 @@ module.exports = class TetrisApp
       installation: this.installation
     };
 
-    this.client.post('/api/v1/tetris/games?', data)
+    this.client.post('/api/v1/interactive/games?', data)
       .then((res) => {
         this.gameId = res.id;
       })


### PR DESCRIPTION
Let's aim to move this into beam-client-node if you can ?

Oh you're also using liveloading in that file. It'll die on october 1st. :(

Let me know if you need help